### PR TITLE
Handle Proxy Adresses

### DIFF
--- a/src/gcp_storage_emulator/storage.py
+++ b/src/gcp_storage_emulator/storage.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import datetime
 import json
 import logging
@@ -279,12 +280,13 @@ class Storage(object):
             return file_content[:total_size]
         return None
 
-    def get_file_obj(self, bucket_name, file_name):
+    def get_file_obj(self, bucket_name, file_name, base_url):
         """Gets the meta information for a file within a bucket
 
         Arguments:
             bucket_name {str} -- Name of the bucket
             file_name {str} -- File name
+            base_url {str} -- Base URL to use for the mediaLink
 
         Raises:
             NotFound: Raised when the object doesn't exist
@@ -294,7 +296,9 @@ class Storage(object):
         """
 
         try:
-            return self.objects[bucket_name][file_name]
+            obj = deepcopy(self.objects[bucket_name][file_name])
+            obj["mediaLink"] = f"{base_url}{obj['mediaLink']}"
+            return obj
         except KeyError:
             raise NotFound
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -50,15 +50,15 @@ class StorageOSFSTests(BaseTestCase):
 
         # Force a re-read from file, this is usually done in the constructor
         self.storage._read_config_from_file()
-        self.assertEqual(self.storage.get_file_obj("key", "inner_key"), "a")
+        self.assertEqual(self.storage.get_file_obj("key", "inner_key", ""), "a")
 
     def test_get_file_obj_not_found(self):
         with self.assertRaises(NotFound):
-            self.storage.get_file_obj("a_bucket", "a_file")
+            self.storage.get_file_obj("a_bucket", "a_file", "")
 
         self.storage.create_bucket("a_bucket", {})
         with self.assertRaises(NotFound):
-            self.storage.get_file_obj("a_bucket", "a_file")
+            self.storage.get_file_obj("a_bucket", "a_file", "")
 
     def test_get_file_not_found(self):
         with self.assertRaises(NotFound):


### PR DESCRIPTION
When being called from different proxies the mediaLink base_url will use the original base_url that was used during upload. However when called from another proxy the mediaLink will reference the original domain it may not have access to.